### PR TITLE
Added note about = sign for archive filename

### DIFF
--- a/source/includes/options-mongorestore.yaml
+++ b/source/includes/options-mongorestore.yaml
@@ -388,6 +388,9 @@ description: |
      - {{program}} still supports the positional ``-`` parameter to
        restore a *single* collection from the standard input.
 
+     - You must use a ``=`` between ``--archive`` and the archive filename
+       when restoring from an archive file.
+     
 optional: true
 ---
 program: mongorestore


### PR DESCRIPTION
It is not clear form the option docs that you have to supply `--archive=<filename>` while most other options can be supplied without the `=` sign.  Although the examples at the bottom of the page do show the = sign, it is nowhere mentioned in the docs the `=` is required which was quite confusing. This commit should better explain that